### PR TITLE
Switch from character and action names to IDs

### DIFF
--- a/praxish.js
+++ b/praxish.js
@@ -133,7 +133,7 @@ function getAllPossibleActions(praxishState, actor) {
     for (const instance of instances) {
       // Get all possible actions for this actor from this instance.
       const instanceID = ground(instancesQuery, instance);
-      for (const actionDef of practiceDef.actions) {
+      for (const [actionIndex, actionDef] of practiceDef.actions.entries()) {
         // Unify this action's conditions with the DB and previous bindings.
         const possibleActions = query(praxishState.db, actionDef.conditions, instance);
         for (const action of possibleActions) {
@@ -141,7 +141,7 @@ function getAllPossibleActions(praxishState, actor) {
           // practice instance, and action definition.
           action.practiceID = practiceID;
           action.instanceID = instanceID;
-          action.actionID = actionDef.name;
+          action.actionID = actionIndex;
           // Swap variable values into the action name template.
           action.name = renderText(actionDef.name, action);
           // Add this possible action to the list of all possible actions.
@@ -269,7 +269,7 @@ function performOutcome(praxishState, outcome) {
 // perform the `action` and return the updated `praxishState`.
 function performAction(praxishState, action) {
   const practiceDef = praxishState.practiceDefs[action.practiceID];
-  const actionDef = practiceDef.actions.find(adef => adef.name === action.actionID);
+  const actionDef = practiceDef.actions.at(action.actionID);
   for (const outcomeDef of actionDef.outcomes || []) {
     const outcome = groundOutcome(outcomeDef, action);
     performOutcome(praxishState, outcome);

--- a/praxish.js
+++ b/praxish.js
@@ -12,7 +12,7 @@ function randNth(items) {
 function renderText(praxishState, template, bindings) {
   let outputText = template;
   for (const [key, value] of Object.entries(bindings)) {
-    outputText = outputText.replaceAll(`[${key}]`, lookupName(praxishState, value));
+    outputText = outputText.replaceAll(`[${key}]`, () => lookupName(praxishState, value));
   }
   return outputText;
 }

--- a/tests.js
+++ b/tests.js
@@ -446,7 +446,7 @@ function doTicks(praxishState, n) {
 const testPraxishState = createPraxishState();
 testPraxishState.allChars = [
   {
-    name: "max",
+    id: "max",
     goals: [
       {
         utility: 10,
@@ -463,7 +463,7 @@ testPraxishState.allChars = [
     ]
   },
   {
-    name: "nic",
+    id: "nic",
     goals: [
       {
         utility: 10,
@@ -476,7 +476,7 @@ testPraxishState.allChars = [
     ]
   },
   {
-    name: "isaac",
+    id: "isaac",
     goals: [
       {
         utility: 5,
@@ -485,7 +485,7 @@ testPraxishState.allChars = [
     ]
   },
   {
-    name: "jukebox",
+    id: "jukebox",
     boundToPractice: "jukebox"
   }
 ];


### PR DESCRIPTION
Currently, actions are identified by `performAction` using the action's name. However, there's no reason why human-readable names need to be unique within a practice. (In fact, duplicating an action with slightly different conditions is the only way to achieve disjunction/OR conditions for actions at the moment.) If two actions in a practice have the same name, currently `performAction` cannot distinguish them and may perform the wrong one.

Another issue is that characters are identified using their `name`, but [the paper](https://ojs.aaai.org/index.php/AIIDE/article/view/27537) describes that key as optional. The `id` key is the only required one, but it's missing from all the test examples in favour of `name`.

This PR changes both actions and characters so they no longer use human-readable `name`s as their main identifier internally.

Actions don't have a documented `id` key, so this PR uses the action's index within its parent practice to identify it within `performAction`. (You could argue it should be a string because it's stored in the `action` object alongside other strings, but this PR keeps it an integer.)

Characters now use their `id` field, and the `name` field is now looked up to format pretty human-readable template strings (such as action descriptions) instead in `renderText`. Though only `id`s that actually appear in the template are looked up, the `renderText` function gets called every time a possible action is generated, so the lookup could make it slow if there are lots of actions and lots of actors. I also implemented a default fallback behaviour for characters without a `name` set, that just displays their `id` with the first letter capitalised.